### PR TITLE
Fix tests for updated API

### DIFF
--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -2,19 +2,21 @@ import { env, createExecutionContext, waitOnExecutionContext, SELF } from 'cloud
 import { describe, it, expect } from 'vitest';
 import worker from '../src';
 
-describe('Hello World worker', () => {
-	it('responds with Hello World! (unit style)', async () => {
-		const request = new Request('http://example.com');
-		// Create an empty context to pass to `worker.fetch()`.
-		const ctx = createExecutionContext();
-		const response = await worker.fetch(request, env, ctx);
-		// Wait for all `Promise`s passed to `ctx.waitUntil()` to settle before running test assertions
-		await waitOnExecutionContext(ctx);
-		expect(await response.text()).toMatchInlineSnapshot(`"Hello World!"`);
-	});
+describe('Help route', () => {
+  it('returns cards info (unit style)', async () => {
+    const request = new Request('http://example.com');
+    const ctx = createExecutionContext();
+    const response = await worker.fetch(request, env, ctx);
+    await waitOnExecutionContext(ctx);
+    const data = await response.json();
+    expect(data).toHaveProperty('themes');
+    expect(data).toHaveProperty('cards');
+  });
 
-	it('responds with Hello World! (integration style)', async () => {
-		const response = await SELF.fetch('http://example.com');
-		expect(await response.text()).toMatchInlineSnapshot(`"Hello World!"`);
-	});
+  it('returns cards info (integration style)', async () => {
+    const response = await SELF.fetch('http://example.com');
+    const data = await response.json();
+    expect(data).toHaveProperty('themes');
+    expect(data).toHaveProperty('cards');
+  });
 });


### PR DESCRIPTION
## Summary
- update tests to check help route output

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fe3e959208332bca57bc4cb8fcc75