### PR TITLE
Fix cache key generation

### DIFF
--- a/src/middleware/withKvCache.js
+++ b/src/middleware/withKvCache.js
@@ -4,9 +4,9 @@ export function withKvCache(handler, { ttl = 7200 } = {}) {
 
     // Build cache key
     const url = new URL(req.url);
+    // Sort parameters by key to ensure consistent cache keys
     const sorted = [...url.searchParams.entries()]
-      .map(([k, v]) => [k, v.toLowerCase()]) // normalise value case
-      .sort(([a], [b]) => a.localeCompare(b)); // sort by key
+      .sort(([a], [b]) => a.localeCompare(b));
     const key = `cache:${url.pathname}?${new URLSearchParams(sorted)}`;
 
     // Return cached response if exists


### PR DESCRIPTION
## Summary
- don't lowercase query params when generating cache key

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fe3cdd4908332abea0173d5b10d79