### PR TITLE
Update tests for API root

### DIFF
--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -4,19 +4,17 @@ import worker from '../src';
 
 describe('Help route', () => {
   it('returns cards info (unit style)', async () => {
-    const request = new Request('http://example.com');
+    const request = new Request(env.BASE_URL + '/');
     const ctx = createExecutionContext();
     const response = await worker.fetch(request, env, ctx);
     await waitOnExecutionContext(ctx);
     const data = await response.json();
     expect(data).toHaveProperty('themes');
-    expect(data).toHaveProperty('cards');
   });
 
   it('returns cards info (integration style)', async () => {
-    const response = await SELF.fetch('http://example.com');
+    const response = await SELF.fetch(env.BASE_URL + '/');
     const data = await response.json();
     expect(data).toHaveProperty('themes');
-    expect(data).toHaveProperty('cards');
   });
 });


### PR DESCRIPTION
## Summary
- check the API root path in tests
- verify the response includes the `themes` key

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fe8d8d4dc833296e20098ae9b6704