### PR TITLE
Fix loadJSONFile not-found handling

### DIFF
--- a/src/utils/load-json-file.js
+++ b/src/utils/load-json-file.js
@@ -1,7 +1,8 @@
 export async function loadJSONFile(env, key) {
   const res = await fetch(`${env.ASSETS_BASE_URL}/data/${key}`);
   if (!res.ok) {
-    throw new Error(`Mock file ${key} not found`);
+    console.error(`Data file ${key} not found`);
+    return null;
   }
   return await res.json();
 }


### PR DESCRIPTION
## Summary
- log a message and return `null` when a data file is missing

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fe8bc14fc83328c4b1449c7b02a85