### PR TITLE
Fix Vitest ESM issues and provide mocks

### DIFF
--- a/src/cards/breaking-bad-quotes.js
+++ b/src/cards/breaking-bad-quotes.js
@@ -1,5 +1,5 @@
 import { loadJSONFile } from '../utils/load-json-file';
-const { Languages, generateHTMLCard } = require("../core/card-generator");
+import { Languages, generateHTMLCard } from "../core/card-generator";
 
 export default async function programmingQuoteHandler({ req, env }) {
   try {

--- a/src/cards/challenge-of-the-week.js
+++ b/src/cards/challenge-of-the-week.js
@@ -1,5 +1,5 @@
 import { loadJSONFile } from '../utils/load-json-file';
-const { Languages, generateHTMLCard } = require("../core/card-generator");
+import { Languages, generateHTMLCard } from "../core/card-generator";
 
 export default async function challengeOfTheWeekHandler({ req, env }) {
   try {

--- a/src/cards/french_word_of_the_day.js
+++ b/src/cards/french_word_of_the_day.js
@@ -1,5 +1,5 @@
 import { loadJSONFile } from '../utils/load-json-file';
-const { Languages, generateHTMLCard } = require('../core/card-generator');
+import { Languages, generateHTMLCard } from '../core/card-generator';
 
 export default async function frenchWordOfTheDayHandler({ req, env }) {
   try {

--- a/src/cards/fun-fact-card.js
+++ b/src/cards/fun-fact-card.js
@@ -1,5 +1,5 @@
 import { loadJSONFile } from '../utils/load-json-file';
-const { Languages, generateHTMLCard } = require('../core/card-generator');
+import { Languages, generateHTMLCard } from '../core/card-generator';
 
 export default async function funFactCardHandler({ req, env }) {
   try {

--- a/src/cards/github-facts.js
+++ b/src/cards/github-facts.js
@@ -1,5 +1,5 @@
 import { loadJSONFile } from '../utils/load-json-file';
-const { Languages, generateHTMLCard } = require('../core/card-generator');
+import { Languages, generateHTMLCard } from '../core/card-generator';
 
 export default async function githubFactsHandler({ req, env }) {
   try {

--- a/src/cards/got-quotes.js
+++ b/src/cards/got-quotes.js
@@ -1,5 +1,5 @@
 import { loadJSONFile } from '../utils/load-json-file';
-const { Languages, generateHTMLCard } = require('../core/card-generator');
+import { Languages, generateHTMLCard } from '../core/card-generator';
 
 export default async function gotQuotesHandler({ req, env }) {
   try {

--- a/src/cards/harry-potter-spells.js
+++ b/src/cards/harry-potter-spells.js
@@ -1,5 +1,5 @@
 import { loadJSONFile } from '../utils/load-json-file';
-const { Languages, generateHTMLCard } = require('../core/card-generator');
+import { Languages, generateHTMLCard } from '../core/card-generator';
 
 export default async function harryPotterSpellsHandler({ req, env }) {
   try {

--- a/src/cards/health-tip-card.js
+++ b/src/cards/health-tip-card.js
@@ -1,5 +1,5 @@
 import { loadJSONFile } from '../utils/load-json-file';
-const { Languages, generateHTMLCard } = require('../core/card-generator');
+import { Languages, generateHTMLCard } from '../core/card-generator';
 
 export default async function healthTipCardHandler({ req, env }) {
   try {

--- a/src/cards/joke-card.js
+++ b/src/cards/joke-card.js
@@ -1,5 +1,5 @@
 import { loadJSONFile } from '../utils/load-json-file';
-const { Languages, generateHTMLCard } = require('../core/card-generator');
+import { Languages, generateHTMLCard } from '../core/card-generator';
 
 export default async function jokeCardHandler({ req, env }) {
   try {

--- a/src/cards/motivational-quote.js
+++ b/src/cards/motivational-quote.js
@@ -1,5 +1,5 @@
 import { loadJSONFile } from '../utils/load-json-file';
-const { Languages, generateHTMLCard } = require('../core/card-generator');
+import { Languages, generateHTMLCard } from '../core/card-generator';
 
 export default async function motivationalQuoteHandler({ req, env }) {
   try {

--- a/src/cards/my-card.js
+++ b/src/cards/my-card.js
@@ -1,5 +1,5 @@
-const { Languages, generateHTMLCard } = require("../core/card-generator");
-const { decodeBase64 } = require("../utils/options-parser");
+import { Languages, generateHTMLCard } from "../core/card-generator";
+import { decodeBase64 } from "../utils/options-parser";
 
 export default async function myCardHandler({ req, env }) {
   try {

--- a/src/cards/programming-facts.js
+++ b/src/cards/programming-facts.js
@@ -1,5 +1,5 @@
 import { loadJSONFile } from '../utils/load-json-file'
-const { Languages, generateHTMLCard } = require("../core/card-generator");
+import { Languages, generateHTMLCard } from "../core/card-generator";
 
 export default async function programmingFactsHandler({ req, env }) {
   try {

--- a/src/cards/programming-quotes.js
+++ b/src/cards/programming-quotes.js
@@ -1,5 +1,5 @@
 import { loadJSONFile } from '../utils/load-json-file'
-const { Languages, generateHTMLCard } = require("../core/card-generator");
+import { Languages, generateHTMLCard } from "../core/card-generator";
 
 export default async function programmingQuoteHandler({ req, env }) {
   try {

--- a/src/cards/random-facts.js
+++ b/src/cards/random-facts.js
@@ -1,5 +1,5 @@
 import { loadJSONFile } from '../utils/load-json-file';
-const { Languages, generateHTMLCard } = require('../core/card-generator');
+import { Languages, generateHTMLCard } from '../core/card-generator';
 
 export default async function randomFactsHandler({ req, env }) {
   try {

--- a/src/cards/security-tips-cards.js
+++ b/src/cards/security-tips-cards.js
@@ -1,5 +1,5 @@
 import { loadJSONFile } from '../utils/load-json-file';
-const { Languages, generateHTMLCard } = require('../core/card-generator');
+import { Languages, generateHTMLCard } from '../core/card-generator';
 
 export default async function securityTipsHandler({ req, env }) {
   try {

--- a/src/cards/spanish-jokes.js
+++ b/src/cards/spanish-jokes.js
@@ -1,5 +1,5 @@
 import { loadJSONFile } from '../utils/load-json-file';
-const { Languages, generateHTMLCard } = require('../core/card-generator');
+import { Languages, generateHTMLCard } from '../core/card-generator';
 
 export default async function spanishJokesHandler({ req, env }) {
   try {

--- a/src/cards/team-work-quote.js
+++ b/src/cards/team-work-quote.js
@@ -1,5 +1,5 @@
 import { loadJSONFile } from '../utils/load-json-file';
-const { Languages, generateHTMLCard } = require('../core/card-generator');
+import { Languages, generateHTMLCard } from '../core/card-generator';
 
 export default async function teamWorkQuoteHandler({ req, env }) {
   try {

--- a/src/cards/top-tweets.js
+++ b/src/cards/top-tweets.js
@@ -1,5 +1,5 @@
 import { loadJSONFile } from '../utils/load-json-file';
-const { Languages, generateHTMLCard } = require('../core/card-generator');
+import { Languages, generateHTMLCard } from '../core/card-generator';
 
 export default async function topTweetsHandler({ req, env }) {
   try {

--- a/src/cards/word_of_the_day.js
+++ b/src/cards/word_of_the_day.js
@@ -1,5 +1,5 @@
 import { loadJSONFile } from '../utils/load-json-file';
-const { Languages, generateHTMLCard } = require('../core/card-generator');
+import { Languages, generateHTMLCard } from '../core/card-generator';
 
 export default async function wordOfTheDayHandler({ req, env }) {
   try {

--- a/src/core/card-generator.js
+++ b/src/core/card-generator.js
@@ -1,8 +1,8 @@
-const { generateSvg, Languages } = require("./satori_renderer");
-const { HTML_THEMES } = require("./themes");
-const { parseOptions } = require("../utils/options-parser");
+import { generateSvg, Languages } from './satori_renderer';
+import { HTML_THEMES } from './themes';
+import { parseOptions } from '../utils/options-parser';
 
-const generateHTMLCard = async (env, html, query, language = Languages.ENGLISH, theme = false) => {
+export const generateHTMLCard = async (env, html, query, language = Languages.ENGLISH, theme = false) => {
   let g_font = null;
   if (theme) {
     theme = theme.toUpperCase();
@@ -70,7 +70,4 @@ const generateHTMLCard = async (env, html, query, language = Languages.ENGLISH, 
   return await generateSvg(html, env, language, g_font);
 }
 
-module.exports.generateHTMLCard = generateHTMLCard;
-
-// Card Options
-module.exports.Languages = Languages;
+export { Languages };

--- a/src/core/themes.js
+++ b/src/core/themes.js
@@ -1,4 +1,4 @@
-const HTML_THEMES = {
+export const HTML_THEMES = {
     'CUSTOM':`
         <div style="display:flex; flex-direction:column; justify-content:center; align-items:center;width:{{card_width}}px; min-height:{{card_min_height}}px;padding:{{outer_pad}}px; background:{{bg_color}};">
             <div style="display:flex; justify-content:{{card_justify}}; align-items:{{card_align}};width:100%; height:100%; padding:{{inner_pad}}px;background:{{card_color}}; border-radius:10px;box-shadow:0 0 10px {{shadow_color}}; box-sizing:border-box; overflow:hidden;">
@@ -182,5 +182,3 @@ const HTML_THEMES = {
         </div>
     `,
 };
-
-module.exports = { HTML_THEMES };

--- a/src/utils/options-parser.js
+++ b/src/utils/options-parser.js
@@ -214,5 +214,4 @@ const parseOptions = (query) => {
     return options;
 };
 
-module.exports.parseOptions = parseOptions;
-module.exports.decodeBase64 = decodeBase64;
+export { parseOptions, decodeBase64 };

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,0 +1,5 @@
+import { vi } from 'vitest';
+vi.mock('satori', () => ({ default: async () => '' }));
+vi.mock('satori-html', () => ({ html: () => '' }));
+vi.mock('css-color-keywords', () => ({}));
+vi.mock('css-to-react-native', () => ({ default: () => [] }));

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,11 +1,17 @@
 import { defineWorkersConfig } from '@cloudflare/vitest-pool-workers/config';
 
 export default defineWorkersConfig({
-	test: {
-		poolOptions: {
-			workers: {
-				wrangler: { configPath: './wrangler.jsonc' },
-			},
-		},
-	},
+        test: {
+                poolOptions: {
+                        workers: {
+                                wrangler: { configPath: './wrangler.jsonc' },
+                        },
+                },
+                setupFiles: './test/setup.js',
+        },
+        esbuild: {
+                loader: {
+                        '.json': 'json'
+                }
+        }
 });


### PR DESCRIPTION
## Summary
- convert CommonJS modules to ESM
- mock heavy deps for Vitest
- load mocks through `setupFiles` in vitest config
- allow JSON loader for Vitest

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683fefdae5f08332b3956cfacac53e4e