### PR TITLE
Add Ocean Breeze theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ All themes are created using HTML and rendered via **Satori**.
 - `lemonade`
 - `galaxy`
 - `vintage`
+- `ocean_breeze`
 
 ### ⚙️ Custom Arguments (for `CUSTOM` theme only)
 
@@ -161,6 +162,9 @@ All themes are created using HTML and rendered via **Satori**.
 
 - **Neon Horizon Theme** <br>
 ![Card](https://github-cards-worker.akanshsirohi-dev.workers.dev/programming-facts-card?theme=neon_horizon)
+
+- **Ocean Breeze Theme** <br>
+![Card](https://github-cards-worker.akanshsirohi-dev.workers.dev/programming-facts-card?theme=ocean_breeze)
 
 - **Custom (Gradient)**  <br>
 ![Custom Gradient](https://github-cards-worker.akanshsirohi-dev.workers.dev/motivational-quotes-card?theme=custom&card_color=bGluZWFyLWdyYWRpZW50KDkwZGVnLHJnYmEoNDIsIDEyMywgMTU1LCAxKSAwJSwgcmdiYSg4NywgMTk5LCAxMzMsIDEpIDUwJSwgcmdiYSgyMzcsIDIyMSwgODMsIDEpIDEwMCUpOw&font_color=fff&bg_color=bGluZWFyLWdyYWRpZW50KDkwZGVnLHJnYmEoMiwgMCwgMzYsIDEpIDAlLCByZ2JhKDksIDksIDEyMSwgMSkgMzUlLCByZ2JhKDAsIDIxMiwgMjU1LCAxKSAxMDAlKTs&shadow_color=fff)

--- a/public/app/config.js
+++ b/public/app/config.js
@@ -33,6 +33,7 @@ export const CARD_TYPES = [
     { value: 'endless_constellation', label: 'Endless Constellation' },
     { value: 'lemonade', label: 'Lemonade' },
     { value: 'vintage', label: 'Vintage' },
+    { value: 'ocean_breeze', label: 'Ocean Breeze' },
     { value: 'galaxy', label: 'Galaxy' },
     { value: 'custom', label: 'Custom' },
   ];

--- a/src/core/themes.js
+++ b/src/core/themes.js
@@ -181,6 +181,15 @@ const HTML_THEMES = {
             </div>
         </div>
     `,
+    'OCEAN_BREEZE': `
+        <div style="display:flex;flex-direction:column;justify-content:center;align-items:center;min-width:400px;max-width:400px;min-height:100px;background:linear-gradient(to right,#2E3192,#1BFFFF);padding:15px;">
+            <div style="display:flex;justify-content:flex-start;align-items:flex-start;width:100%;height:100%;background:#ffffff;padding:15px;border-radius:10px;box-sizing:border-box;overflow:hidden;box-shadow:0 0 10px rgba(0,0,0,0.1);">
+                <div style="display:flex;flex-direction:column;align-items:flex-start;white-space:pre-line;text-align:left;">
+                    <span style="font-size:11px;font-weight:bold;color:#333;">{{card_content}}</span>
+                </div>
+            </div>
+        </div>
+    `,
 };
 
 module.exports = { HTML_THEMES };

--- a/src/help.js
+++ b/src/help.js
@@ -108,22 +108,34 @@ export default async function helpHandler({ req, env }) {
         `${baseurl}/random-facts-card?theme=vintage`,
         `${baseurl}/harry-potter-spell-card?theme=vintage`,
       ],
-    },
-    galaxy: {
-      info: "Galaxy theme",
-      example: [
-        `${baseurl}/jokes-card?theme=galaxy`,
-        `${baseurl}/programming-quotes-card?theme=galaxy`,
-        `${baseurl}/programming-facts-card?theme=galaxy`,
-        `${baseurl}/motivational-quotes-card?theme=galaxy`,
-        `${baseurl}/random-facts-card?theme=galaxy`,
-      ],
-    },
-    custom: {
-      info: "Custom theme",
-      args: {
-        card_color: "Card color, with gradient support. Refer to README.md for more info. Default: #ffffff [Optional]",
-        font_color: "Card text color. Default: #000000 [Optional]",
+      },
+      galaxy: {
+        info: "Galaxy theme",
+        example: [
+          `${baseurl}/jokes-card?theme=galaxy`,
+          `${baseurl}/programming-quotes-card?theme=galaxy`,
+          `${baseurl}/programming-facts-card?theme=galaxy`,
+          `${baseurl}/motivational-quotes-card?theme=galaxy`,
+          `${baseurl}/random-facts-card?theme=galaxy`,
+        ],
+      },
+      ocean_breeze: {
+        info: "Ocean Breeze Theme",
+        example: [
+          `${baseurl}/jokes-card?theme=ocean_breeze`,
+          `${baseurl}/programming-quotes-card?theme=ocean_breeze`,
+          `${baseurl}/programming-facts-card?theme=ocean_breeze`,
+          `${baseurl}/motivational-quotes-card?theme=ocean_breeze`,
+          `${baseurl}/travel-destinations-card?theme=ocean_breeze`,
+          `${baseurl}/random-facts-card?theme=ocean_breeze`,
+          `${baseurl}/harry-potter-spell-card?theme=ocean_breeze`,
+        ],
+      },
+      custom: {
+        info: "Custom theme",
+        args: {
+          card_color: "Card color, with gradient support. Refer to README.md for more info. Default: #ffffff [Optional]",
+          font_color: "Card text color. Default: #000000 [Optional]",
         bg_color: "Card background color, with gradient support. Refer to README.md for more info. Default: #ffffff [Optional]",
         shadow_color: "Card shadow color. Default: #00000000 [Optional]",
         google_font: "Custom google font. Default: none [Optional]",


### PR DESCRIPTION
## Summary
- add Ocean Breeze theme definition
- document new theme in help output
- expose Ocean Breeze theme in the web UI dropdown
- mention Ocean Breeze in README with example card

## Testing
- `npm test` *(fails: No such module "workspace/Github-Cards-API/src/core/satori_renderer")*

------
https://chatgpt.com/codex/tasks/task_e_68407db062c4833285a954b08cbabe1d