### PR TITLE
Rename Breaking Bad quote handler

### DIFF
--- a/src/cards/breaking-bad-quotes.js
+++ b/src/cards/breaking-bad-quotes.js
@@ -1,7 +1,7 @@
 import { loadJSONFile } from '../utils/load-json-file';
 import { Languages, generateHTMLCard } from "../core/card-generator";
 
-export default async function programmingQuoteHandler({ req, env }) {
+export default async function breakingBadQuoteHandler({ req, env }) {
   try {
     const programmingQuotesData = await loadJSONFile(env, 'breaking-bad-quotes.json');
 


### PR DESCRIPTION
## Summary
- rename handler `breakingBadQuoteHandler` in `breaking-bad-quotes.js`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ea70e534083329852935d612b3d5b