### PR TITLE
Rename google_font_loader function

### DIFF
--- a/src/core/satori_renderer.js
+++ b/src/core/satori_renderer.js
@@ -1,6 +1,6 @@
 import { html as parseHTML } from 'satori-html'
 import satori from 'satori';
-import {google_font_loader} from "../utils/google-fonts-loader";
+import {googleFontLoader} from "../utils/google-fonts-loader";
 
 // Supported Languages
 export const Languages = {
@@ -31,7 +31,7 @@ export async function generateSvg(html_code, env, language = Languages.ENGLISH, 
         }
 
         if (google_font) {
-            const fontData = await google_font_loader(google_font);
+            const fontData = await googleFontLoader(google_font);
             if (fontData) {
                 return {
                     name: fontData.fontFamily,

--- a/src/utils/google-fonts-loader.js
+++ b/src/utils/google-fonts-loader.js
@@ -1,4 +1,4 @@
-export async function google_font_loader(font) {
+export async function googleFontLoader(font) {
     font = font.replace(/\s+/g, '+');
     const res = await fetch(
         `https://fonts.googleapis.com/css2?family=${font}`,


### PR DESCRIPTION
## Summary
- rename `google_font_loader` util to `googleFontLoader`
- update satori renderer to use the new function name

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684ead0822208332b91fd758e74bc12a